### PR TITLE
Mark as deprecated, refer to new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+### Notice
+This Perl version of BioNetFit is deprecated, but remains available for archival purposes. The new version of BioNetFit is available at https://github.com/lanl/PyBNF.
+
 ### BioNetFit
 BioNetFit is a general-purpose fitting program for rule-based models written in the BioNetGen language. 
 


### PR DESCRIPTION
Now that the new PyBioNetFit is available online, new users should be directed to that version. Updated the readme with a link to the PyBioNetFit repository.